### PR TITLE
feat: update StaticATokenRateProvider to bypass waToken for gas savings

### DIFF
--- a/contracts/interfaces/ILendingPool.sol
+++ b/contracts/interfaces/ILendingPool.sol
@@ -14,21 +14,9 @@
 
 pragma solidity ^0.8.0;
 
-import "./ILendingPool.sol";
-
-interface IStaticAToken {
-    /**
-     * @dev returns the address of the staticAToken's underlying asset
-     */
-    function ASSET() external view returns (address);
-
-    /**
-     * @dev returns the address of the staticAToken's lending pool
-     */
-    function LENDING_POOL() external view returns (ILendingPool);
-
+interface ILendingPool {
     /**
      * @dev returns a 27 decimal fixed point 'ray' value so a rate of 1 is represented as 1e27
      */
-    function rate() external view returns (uint256);
+    function getReserveNormalizedIncome(address asset) external view returns (uint256);
 }


### PR DESCRIPTION
As a given waToken is tied to a particular aToken (and so lending pool) we can safely pull the data required for querying it's value directly from the relevant lending pool in order to save gas (avoiding the need for 2 SLOADs and an external call).

The only situation in which this breaks down is if Aave changes the underlying implementation of the waToken which breaks the waToken catastrophically (by making it think that it holds a different asset or assets on a different lending pool).

Implementation taken from: 
https://github.com/aave/protocol-v2/blob/ac58fea62bb8afee23f66197e8bce6d79ecda292/contracts/protocol/tokenization/StaticATokenLM.sol#L255-L257